### PR TITLE
Add CI GitHub Action to lint and test code

### DIFF
--- a/.github/workflows/test-python-app.yaml
+++ b/.github/workflows/test-python-app.yaml
@@ -1,0 +1,33 @@
+name: Lint and Test Python Code
+
+on:
+  pull_request:
+    branches: [$default-branch]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest


### PR DESCRIPTION
Adds a CI step that runs lint checks and unit tests whenever a PR is made to the default branch. This is useful for automatically doing sanity checks on code before it gets merged to main. This should resolve #24 