### PR TITLE
Deploy specific app versions based on image tag

### DIFF
--- a/k8s/chatinsights.yaml
+++ b/k8s/chatinsights.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: chat-insights
-        image: andilejaden/chatinsight
+        image: andilejaden/chatinsight:sha-b7ef52e
         imagePullPolicy: Always
         ports:
           - containerPort: 8000


### PR DESCRIPTION
This PR updates the deployment to use a specific Docker tag instead of the implicit `latest`. Pinning deployments to fixed tags is a best practice that ensures only tested, verified and approved versions are deployed to production. The tags are generated from git commit SHA's automatically in the CI/CD workflows or they can be generated manually by running:

```shell
git rev-parse --short HEAD
```
in the main branch.

Image tags can be copied from DockerHub; https://hub.docker.com/r/andilejaden/chatinsight/tags

![image](https://github.com/user-attachments/assets/3c7e111b-7d65-4252-8e9d-001b43d14593)
