### PR TITLE
feat: Implement download_results endpoint to consolidate results into one .zip file instead of many separate images iteratively.

### DIFF
--- a/k8s/chatinsights.yaml
+++ b/k8s/chatinsights.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: chat-insights
-        image: andilejaden/chatinsight:sha-e07d5d4
+        image: andilejaden/chatinsight:sha-a03e5ef
         imagePullPolicy: Always
         ports:
           - containerPort: 8000

--- a/templates/results.html
+++ b/templates/results.html
@@ -1879,31 +1879,25 @@
       }
 
       async function downloadAllVisuals() {
-        const images = document.querySelectorAll(".chart-container img");
-        let count = 0;
-
-        for (const img of images) {
-          try {
-            const title = img
-              .closest(".chart-container")
-              .previousElementSibling.textContent.trim();
-            const response = await fetch(img.src);
-            const blob = await response.blob();
-            const url = window.URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `${title}.png`;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            window.URL.revokeObjectURL(url);
-            count++;
-          } catch (error) {
-            console.error("Error downloading:", error);
+        try {
+          const response = await fetch("/download_results");
+          if (!response.ok) {
+            throw new Error("Failed to download visualizations.");
           }
+          const blob = await response.blob();
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "{user_id}_visualizations.zip";
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          window.URL.revokeObjectURL(url);
+          showToast("Downloaded visualizations as a single ZIP file");
+        } catch (error) {
+          console.error("Error downloading ZIP:", error);
+          showToast("Unable to download visuals. Please try again.");
         }
-
-        showToast(`Downloaded ${count} visualizations`);
         toggleShareMenu();
       }
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -1888,7 +1888,6 @@
           const url = window.URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = url;
-          a.download = "{user_id}_visualizations.zip";
           document.body.appendChild(a);
           a.click();
           document.body.removeChild(a);


### PR DESCRIPTION
This PR refactors the download functionality to improve the user experience by consolidating all visualization downloads into a single ZIP file. Previously, users had to download each visualization image individually, which could be inefficient and cumbersome. The changes include:

Front-End Updates:
- Modified the downloadAllVisuals() JavaScript function in the results page to trigger a single request to the new backend endpoint (/download_results) that returns a ZIP file containing all visualization images.
- Updated the user feedback via toast notifications to indicate that a single ZIP file has been downloaded.

Back-End Updates:
- Implemented the /download_results endpoint in app.py which packages all visualization files from the user’s directory into an in-memory ZIP file and streams it back to the client.
- Ensured that session validation and security checks remain intact.

Please review and let me know if any adjustments are needed.

Closes: #48